### PR TITLE
fix: correct tax slabs to match NBR official documentation

### DIFF
--- a/src/utils/taxSlabs.js
+++ b/src/utils/taxSlabs.js
@@ -1,8 +1,8 @@
 const LAKH = 100000;
 
 // Bangladesh Tax Slab Structure (amounts in lakh)
-const TAX_SLAB_AMOUNTS = [1, 4, 5, 5, 20]; // After threshold: 1L, 4L, 5L, 5L, 20L
-const TAX_RATES = [0, 5, 10, 15, 20, 25, 30]; // 0% for threshold, then 5%, 10%, etc.
+const TAX_SLAB_AMOUNTS = [1, 4, 5, 5]; // After threshold: 1L, 4L, 5L, 5L
+const TAX_RATES = [0, 5, 10, 15, 20, 25]; // 0% for threshold, then 5%, 10%, 15%, 20%, 25%
 
 const formatLakh = (lakhs) => {
   return lakhs === Math.floor(lakhs) ? `${lakhs}` : `${lakhs.toFixed(1)}`;

--- a/src/utils/taxSlabs2025.js
+++ b/src/utils/taxSlabs2025.js
@@ -1,9 +1,9 @@
 const LAKH = 100000;
 
 // Bangladesh Tax Slab Structure FY 2025-2026 (amounts in lakh)
-// Note: 5% bracket has been removed, structure simplified to 6 slabs
-const TAX_SLAB_AMOUNTS_2025 = [3, 4, 5, 20]; // After threshold: 3L, 4L, 5L, 20L
-const TAX_RATES_2025 = [0, 10, 15, 20, 25, 30]; // 0% for threshold, then 10%, 15%, etc. (no 5%)
+// Based on NBR official documentation - same structure as FY 2024-2025
+const TAX_SLAB_AMOUNTS_2025 = [1, 4, 5, 5]; // After threshold: 1L, 4L, 5L, 5L
+const TAX_RATES_2025 = [0, 5, 10, 15, 20, 25]; // 0% for threshold, then 5%, 10%, 15%, 20%, 25%
 
 const formatLakh = (lakhs) => {
   return lakhs === Math.floor(lakhs) ? `${lakhs}` : `${lakhs.toFixed(1)}`;
@@ -54,16 +54,16 @@ export function calculateTaxSlabs2025(taxFreeThreshold) {
 
 /**
  * Get tax-free thresholds for FY 2025-2026
- * Updated thresholds: +25,000 BDT across all categories
+ * Based on NBR official documentation
  */
 export const TAX_FREE_THRESHOLDS_2025 = {
-  general: 375000,        // +25K from 350K
-  female: 425000,         // +25K from 400K
-  senior: 425000,         // +25K from 400K (65+ years)
-  disabled: 500000,       // +25K from 475K
-  third_gender: 500000,   // +25K from 475K
-  freedom_fighter: 525000, // +25K from 500K
-  parent_disabled: 425000  // 375K + 50K exemption
+  general: 350000,        // 3.5 lakh
+  female: 400000,         // 4.0 lakh
+  senior: 400000,         // 4.0 lakh (65+ years)
+  disabled: 475000,       // 4.75 lakh
+  third_gender: 475000,   // 4.75 lakh
+  freedom_fighter: 500000, // 5.0 lakh
+  parent_disabled: 400000  // 4.0 lakh
 };
 
 /**

--- a/tests/unit/calculation2025.test.js
+++ b/tests/unit/calculation2025.test.js
@@ -80,13 +80,13 @@ describe('Calculation-2025 Component', () => {
       expect(totalTaxDisplay.text()).toContain(wrapper.vm.totalTax.toString());
     });
 
-    test('should use FY 2025-26 tax slabs (6 slabs, no 5% bracket)', () => {
+    test('should use FY 2025-26 tax slabs (7 slabs, includes 5% bracket)', () => {
       store.commit('updateTaxpayerProfile', {
         category: 'general',
         age: 30,
         location: 'dhaka'
       });
-      
+
       store.commit('changeSubsequentSalaries', { index: 0, value: 50000 }); // 600K annually
 
       wrapper = mount(Calculation2025, {
@@ -96,16 +96,16 @@ describe('Calculation-2025 Component', () => {
       });
 
       const taxBreakdown = wrapper.vm.taxBreakdown;
-      
-      expect(taxBreakdown).toHaveLength(6); // 6 slabs for 2025-26
-      
-      // Check that tax rates don't include 5%
+
+      expect(taxBreakdown).toHaveLength(7); // 7 slabs for 2025-26
+
+      // Check that tax rates include 5%
       const rates = taxBreakdown.map(slab => slab.slabPercentage);
-      expect(rates).not.toContain(5);
-      expect(rates).toEqual([0, 10, 15, 20, 25, 30]);
+      expect(rates).toContain(5);
+      expect(rates).toEqual([0, 5, 10, 15, 20, 25]);
     });
 
-    test('should show higher tax-free threshold for 2025-26', () => {
+    test('should show tax-free threshold for 2025-26', () => {
       store.commit('updateTaxpayerProfile', {
         category: 'general',
         age: 30,
@@ -119,7 +119,7 @@ describe('Calculation-2025 Component', () => {
       });
 
       const threshold = wrapper.vm.taxFreeThreshold;
-      expect(threshold).toBe(375000); // 25K higher than 2024-25
+      expect(threshold).toBe(350000); // Same as 2024-25 per NBR official
     });
 
     test('should apply unified minimum tax of 5000', () => {
@@ -161,7 +161,7 @@ describe('Calculation-2025 Component', () => {
       });
 
       const threshold = wrapper.vm.taxFreeThreshold;
-      expect(threshold).toBe(425000); // Female threshold for 2025-26
+      expect(threshold).toBe(400000); // Female threshold for 2025-26
     });
 
     test('should calculate correctly for disabled person', () => {
@@ -178,7 +178,7 @@ describe('Calculation-2025 Component', () => {
       });
 
       const threshold = wrapper.vm.taxFreeThreshold;
-      expect(threshold).toBe(500000); // Disabled threshold for 2025-26
+      expect(threshold).toBe(475000); // Disabled threshold for 2025-26
     });
 
     test('should calculate correctly for freedom fighter', () => {
@@ -195,7 +195,7 @@ describe('Calculation-2025 Component', () => {
       });
 
       const threshold = wrapper.vm.taxFreeThreshold;
-      expect(threshold).toBe(525000); // Freedom fighter threshold for 2025-26
+      expect(threshold).toBe(500000); // Freedom fighter threshold for 2025-26
     });
 
     test('should calculate correctly for third gender', () => {
@@ -212,7 +212,7 @@ describe('Calculation-2025 Component', () => {
       });
 
       const threshold = wrapper.vm.taxFreeThreshold;
-      expect(threshold).toBe(500000); // Third gender threshold for 2025-26
+      expect(threshold).toBe(475000); // Third gender threshold for 2025-26
     });
 
     test('should auto-detect senior citizen', () => {
@@ -229,7 +229,7 @@ describe('Calculation-2025 Component', () => {
       });
 
       const threshold = wrapper.vm.taxFreeThreshold;
-      expect(threshold).toBe(425000); // Senior threshold for 2025-26
+      expect(threshold).toBe(400000); // Senior threshold for 2025-26
     });
   });
 
@@ -258,13 +258,13 @@ describe('Calculation-2025 Component', () => {
       expect(totalTax).toBe(minimumTax); // Should apply minimum tax
     });
 
-    test('should calculate correct tax for income in first bracket (10%)', () => {
+    test('should calculate correct tax for income in first bracket (5%)', () => {
       store.commit('updateTaxpayerProfile', {
         category: 'general',
         age: 30,
         location: 'dhaka'
       });
-      
+
       store.commit('changeSubsequentSalaries', { index: 0, value: 40000 }); // 480K annually
 
       wrapper = mount(Calculation2025, {
@@ -274,10 +274,10 @@ describe('Calculation-2025 Component', () => {
       });
 
       const taxBreakdown = wrapper.vm.taxBreakdown;
-      
-      expect(taxBreakdown[0].slabCut).toBe(0); // No tax on first 375K
-      expect(taxBreakdown[1].slabCut).toBeGreaterThan(0); // Tax on excess at 10%
-      expect(taxBreakdown[1].slabPercentage).toBe(10); // First taxable bracket is 10%
+
+      expect(taxBreakdown[0].slabCut).toBe(0); // No tax on first 350K
+      expect(taxBreakdown[1].slabCut).toBeGreaterThan(0); // Tax on excess at 5%
+      expect(taxBreakdown[1].slabPercentage).toBe(5); // First taxable bracket is 5%
     });
 
     test('should apply minimum tax when calculated tax is lower', () => {
@@ -546,8 +546,8 @@ describe('Calculation-2025 Component', () => {
         age: 30,
         location: 'dhaka'
       });
-      
-      store.commit('changeSubsequentSalaries', { index: 0, value: 31250 }); // Exactly 375K annually
+
+      store.commit('changeSubsequentSalaries', { index: 0, value: 29167 }); // Exactly 350K annually
 
       wrapper = mount(Calculation2025, {
         global: {
@@ -558,7 +558,7 @@ describe('Calculation-2025 Component', () => {
       const taxBreakdown = wrapper.vm.taxBreakdown;
       const totalTax = wrapper.vm.totalTax;
       const minimumTax = wrapper.vm.minimumTaxAmount;
-      
+
       expect(taxBreakdown[0].slabCut).toBe(0);
       expect(totalTax).toBe(minimumTax); // Should apply minimum tax
     });
@@ -569,7 +569,7 @@ describe('Calculation-2025 Component', () => {
         age: 30,
         location: 'dhaka'
       });
-      
+
       store.commit('changeSubsequentSalaries', { index: 0, value: 500000 }); // 6M annually
 
       wrapper = mount(Calculation2025, {
@@ -580,8 +580,8 @@ describe('Calculation-2025 Component', () => {
 
       const taxBreakdown = wrapper.vm.taxBreakdown;
       const totalTax = wrapper.vm.totalTax;
-      
-      expect(taxBreakdown).toHaveLength(6);
+
+      expect(taxBreakdown).toHaveLength(7);
       expect(taxBreakdown[5].slabCut).toBeGreaterThan(0); // Highest slab should have tax
       expect(totalTax).toBeGreaterThan(100000); // Substantial tax amount
     });
@@ -592,7 +592,7 @@ describe('Calculation-2025 Component', () => {
         age: 30,
         location: 'dhaka'
       });
-      
+
       store.commit('changeSubsequentSalaries', { index: 0, value: 40000 });
 
       wrapper = mount(Calculation2025, {
@@ -602,8 +602,8 @@ describe('Calculation-2025 Component', () => {
       });
 
       const initialThreshold = wrapper.vm.taxFreeThreshold;
-      expect(initialThreshold).toBe(375000);
-      
+      expect(initialThreshold).toBe(350000);
+
       store.commit('updateTaxpayerProfile', {
         category: 'disabled',
         age: 30,
@@ -611,7 +611,7 @@ describe('Calculation-2025 Component', () => {
       });
 
       const newThreshold = wrapper.vm.taxFreeThreshold;
-      expect(newThreshold).toBe(500000);
+      expect(newThreshold).toBe(475000);
     });
   });
 

--- a/tests/unit/taxSlabs2025.test.js
+++ b/tests/unit/taxSlabs2025.test.js
@@ -11,21 +11,21 @@ import {
 describe('Tax Slabs 2025 Utility Functions', () => {
   describe('TAX_FREE_THRESHOLDS_2025 Constants', () => {
     test('should have correct thresholds for all categories', () => {
-      expect(TAX_FREE_THRESHOLDS_2025.general).toBe(375000);
-      expect(TAX_FREE_THRESHOLDS_2025.female).toBe(425000);
-      expect(TAX_FREE_THRESHOLDS_2025.senior).toBe(425000);
-      expect(TAX_FREE_THRESHOLDS_2025.disabled).toBe(500000);
-      expect(TAX_FREE_THRESHOLDS_2025.third_gender).toBe(500000);
-      expect(TAX_FREE_THRESHOLDS_2025.freedom_fighter).toBe(525000);
-      expect(TAX_FREE_THRESHOLDS_2025.parent_disabled).toBe(425000);
+      expect(TAX_FREE_THRESHOLDS_2025.general).toBe(350000);
+      expect(TAX_FREE_THRESHOLDS_2025.female).toBe(400000);
+      expect(TAX_FREE_THRESHOLDS_2025.senior).toBe(400000);
+      expect(TAX_FREE_THRESHOLDS_2025.disabled).toBe(475000);
+      expect(TAX_FREE_THRESHOLDS_2025.third_gender).toBe(475000);
+      expect(TAX_FREE_THRESHOLDS_2025.freedom_fighter).toBe(500000);
+      expect(TAX_FREE_THRESHOLDS_2025.parent_disabled).toBe(400000);
     });
 
-    test('should show correct increase from 2024-25 thresholds', () => {
-      // All categories increased by 25,000 BDT
-      expect(TAX_FREE_THRESHOLDS_2025.general - 350000).toBe(25000);
-      expect(TAX_FREE_THRESHOLDS_2025.female - 400000).toBe(25000);
-      expect(TAX_FREE_THRESHOLDS_2025.disabled - 475000).toBe(25000);
-      expect(TAX_FREE_THRESHOLDS_2025.freedom_fighter - 500000).toBe(25000);
+    test('should have same thresholds as 2024-25 (NBR official)', () => {
+      // Based on NBR official documentation - same as 2024-25
+      expect(TAX_FREE_THRESHOLDS_2025.general).toBe(350000);
+      expect(TAX_FREE_THRESHOLDS_2025.female).toBe(400000);
+      expect(TAX_FREE_THRESHOLDS_2025.disabled).toBe(475000);
+      expect(TAX_FREE_THRESHOLDS_2025.freedom_fighter).toBe(500000);
     });
   });
 
@@ -41,45 +41,45 @@ describe('Tax Slabs 2025 Utility Functions', () => {
   describe('getTaxFreeThreshold2025', () => {
     test('should return correct threshold for general taxpayer', () => {
       const profile = { category: 'general', age: 30 };
-      expect(getTaxFreeThreshold2025(profile)).toBe(375000);
+      expect(getTaxFreeThreshold2025(profile)).toBe(350000);
     });
 
     test('should return correct threshold for female taxpayer', () => {
       const profile = { category: 'female', age: 30 };
-      expect(getTaxFreeThreshold2025(profile)).toBe(425000);
+      expect(getTaxFreeThreshold2025(profile)).toBe(400000);
     });
 
     test('should return correct threshold for disabled person', () => {
       const profile = { category: 'disabled', age: 35 };
-      expect(getTaxFreeThreshold2025(profile)).toBe(500000);
+      expect(getTaxFreeThreshold2025(profile)).toBe(475000);
     });
 
     test('should return correct threshold for freedom fighter', () => {
       const profile = { category: 'freedom_fighter', age: 35 };
-      expect(getTaxFreeThreshold2025(profile)).toBe(525000);
+      expect(getTaxFreeThreshold2025(profile)).toBe(500000);
     });
 
     test('should return correct threshold for third gender', () => {
       const profile = { category: 'third_gender', age: 30 };
-      expect(getTaxFreeThreshold2025(profile)).toBe(500000);
+      expect(getTaxFreeThreshold2025(profile)).toBe(475000);
     });
 
     test('should auto-detect senior citizen based on age', () => {
       const profile = { category: 'general', age: 67 };
-      expect(getTaxFreeThreshold2025(profile)).toBe(425000);
+      expect(getTaxFreeThreshold2025(profile)).toBe(400000);
     });
 
     test('should not override higher threshold categories with senior detection', () => {
       const disabledSenior = { category: 'disabled', age: 70 };
-      expect(getTaxFreeThreshold2025(disabledSenior)).toBe(500000); // Should remain disabled threshold
-      
+      expect(getTaxFreeThreshold2025(disabledSenior)).toBe(475000); // Should remain disabled threshold
+
       const freedomFighterSenior = { category: 'freedom_fighter', age: 70 };
-      expect(getTaxFreeThreshold2025(freedomFighterSenior)).toBe(525000); // Should remain freedom fighter threshold
+      expect(getTaxFreeThreshold2025(freedomFighterSenior)).toBe(500000); // Should remain freedom fighter threshold
     });
 
     test('should default to general threshold for unknown categories', () => {
       const profile = { category: 'unknown', age: 30 };
-      expect(getTaxFreeThreshold2025(profile)).toBe(375000);
+      expect(getTaxFreeThreshold2025(profile)).toBe(350000);
     });
   });
 
@@ -97,72 +97,72 @@ describe('Tax Slabs 2025 Utility Functions', () => {
   });
 
   describe('calculateTaxSlabs2025', () => {
-    test('should generate correct tax slabs for general taxpayer (375k threshold)', () => {
-      const slabs = calculateTaxSlabs2025(375000);
-      
-      expect(slabs).toHaveLength(6); // 6 slabs total (removed 5% bracket)
-      
+    test('should generate correct tax slabs for general taxpayer (350k threshold)', () => {
+      const slabs = calculateTaxSlabs2025(350000);
+
+      expect(slabs).toHaveLength(7); // 7 slabs total (includes 5% bracket)
+
       // First slab (tax-free)
-      expect(slabs[0]).toEqual(['First Tk3.8 lakh [0-3.8 lakh]', 0, 375000, 0]);
-      
-      // Second slab (10%)
-      expect(slabs[1]).toEqual(['Next Tk3 lakh [3.8-6.8 lakh]', 375000, 675000, 10]);
-      
-      // Third slab (15%)
-      expect(slabs[2]).toEqual(['Next Tk4 lakh [6.8-10.8 lakh]', 675000, 1075000, 15]);
-      
-      // Fourth slab (20%)
-      expect(slabs[3]).toEqual(['Next Tk5 lakh [10.8-15.8 lakh]', 1075000, 1575000, 20]);
-      
-      // Fifth slab (25%)
-      expect(slabs[4]).toEqual(['Next Tk20 lakh [15.8-35.8 lakh]', 1575000, 3575000, 25]);
-      
-      // Sixth slab (30%)
-      expect(slabs[5]).toEqual(['Above [35.8-UP lakh]', 3575000, Infinity, 30]);
+      expect(slabs[0]).toEqual(['First Tk3.5 lakh [0-3.5 lakh]', 0, 350000, 0]);
+
+      // Second slab (5%)
+      expect(slabs[1]).toEqual(['Next Tk1 lakh [3.5-4.5 lakh]', 350000, 450000, 5]);
+
+      // Third slab (10%)
+      expect(slabs[2]).toEqual(['Next Tk4 lakh [4.5-8.5 lakh]', 450000, 850000, 10]);
+
+      // Fourth slab (15%)
+      expect(slabs[3]).toEqual(['Next Tk5 lakh [8.5-13.5 lakh]', 850000, 1350000, 15]);
+
+      // Fifth slab (20%)
+      expect(slabs[4]).toEqual(['Next Tk5 lakh [13.5-18.5 lakh]', 1350000, 1850000, 20]);
+
+      // Sixth slab (25%)
+      expect(slabs[5]).toEqual(['Above [18.5-UP lakh]', 1850000, Infinity, 25]);
     });
 
-    test('should generate correct tax slabs for female taxpayer (425k threshold)', () => {
-      const slabs = calculateTaxSlabs2025(425000);
-      
-      expect(slabs).toHaveLength(6);
-      
+    test('should generate correct tax slabs for female taxpayer (400k threshold)', () => {
+      const slabs = calculateTaxSlabs2025(400000);
+
+      expect(slabs).toHaveLength(7);
+
       // First slab should reflect higher threshold
-      expect(slabs[0]).toEqual(['First Tk4.3 lakh [0-4.3 lakh]', 0, 425000, 0]);
-      expect(slabs[1]).toEqual(['Next Tk3 lakh [4.3-7.3 lakh]', 425000, 725000, 10]);
+      expect(slabs[0]).toEqual(['First Tk4 lakh [0-4 lakh]', 0, 400000, 0]);
+      expect(slabs[1]).toEqual(['Next Tk1 lakh [4-5 lakh]', 400000, 500000, 5]);
     });
 
-    test('should generate correct tax slabs for disabled person (500k threshold)', () => {
+    test('should generate correct tax slabs for disabled person (475k threshold)', () => {
+      const slabs = calculateTaxSlabs2025(475000);
+
+      expect(slabs).toHaveLength(7);
+
+      // First slab should reflect higher threshold
+      expect(slabs[0]).toEqual(['First Tk4.8 lakh [0-4.8 lakh]', 0, 475000, 0]);
+      expect(slabs[1]).toEqual(['Next Tk1 lakh [4.8-5.8 lakh]', 475000, 575000, 5]);
+    });
+
+    test('should generate correct tax slabs for freedom fighter (500k threshold)', () => {
       const slabs = calculateTaxSlabs2025(500000);
-      
-      expect(slabs).toHaveLength(6);
-      
-      // First slab should reflect higher threshold
-      expect(slabs[0]).toEqual(['First Tk5 lakh [0-5 lakh]', 0, 500000, 0]);
-      expect(slabs[1]).toEqual(['Next Tk3 lakh [5-8 lakh]', 500000, 800000, 10]);
-    });
 
-    test('should generate correct tax slabs for freedom fighter (525k threshold)', () => {
-      const slabs = calculateTaxSlabs2025(525000);
-      
-      expect(slabs).toHaveLength(6);
-      
+      expect(slabs).toHaveLength(7);
+
       // First slab should reflect highest threshold
-      expect(slabs[0]).toEqual(['First Tk5.3 lakh [0-5.3 lakh]', 0, 525000, 0]);
-      expect(slabs[1]).toEqual(['Next Tk3 lakh [5.3-8.3 lakh]', 525000, 825000, 10]);
+      expect(slabs[0]).toEqual(['First Tk5 lakh [0-5 lakh]', 0, 500000, 0]);
+      expect(slabs[1]).toEqual(['Next Tk1 lakh [5-6 lakh]', 500000, 600000, 5]);
     });
 
     test('should have correct tax rates in order', () => {
-      const slabs = calculateTaxSlabs2025(375000);
+      const slabs = calculateTaxSlabs2025(350000);
       const rates = slabs.map(slab => slab[3]);
-      
-      expect(rates).toEqual([0, 10, 15, 20, 25, 30]);
+
+      expect(rates).toEqual([0, 5, 10, 15, 20, 25]);
     });
 
-    test('should have no 5% bracket (removed in 2025-26)', () => {
-      const slabs = calculateTaxSlabs2025(375000);
+    test('should have 5% bracket (same as 2024-25 NBR structure)', () => {
+      const slabs = calculateTaxSlabs2025(350000);
       const rates = slabs.map(slab => slab[3]);
-      
-      expect(rates).not.toContain(5);
+
+      expect(rates).toContain(5);
     });
   });
 
@@ -222,17 +222,17 @@ describe('Tax Slabs 2025 Utility Functions', () => {
       profiles.forEach(profile => {
         const threshold = getTaxFreeThreshold2025(profile);
         const slabs = calculateTaxSlabs2025(threshold);
-        
+
         expect(threshold).toBeGreaterThan(0);
-        expect(slabs).toHaveLength(6);
+        expect(slabs).toHaveLength(7);
         expect(slabs[0][2]).toBe(threshold); // First slab upper limit should match threshold
         expect(slabs[0][3]).toBe(0); // First slab should be tax-free
       });
     });
 
     test('should maintain slab progression', () => {
-      const slabs = calculateTaxSlabs2025(375000);
-      
+      const slabs = calculateTaxSlabs2025(350000);
+
       for (let i = 1; i < slabs.length; i++) {
         if (slabs[i][2] !== Infinity) {
           expect(slabs[i][1]).toBe(slabs[i-1][2]); // Each slab should start where previous ends
@@ -244,36 +244,36 @@ describe('Tax Slabs 2025 Utility Functions', () => {
     test('should handle all threshold values correctly', () => {
       Object.values(TAX_FREE_THRESHOLDS_2025).forEach(threshold => {
         const slabs = calculateTaxSlabs2025(threshold);
-        expect(slabs).toHaveLength(6);
+        expect(slabs).toHaveLength(7);
         expect(slabs[0][2]).toBe(threshold);
       });
     });
   });
 
   describe('Comparison with 2024-25 Rules', () => {
-    test('should have higher thresholds than 2024-25', () => {
-      const oldThresholds = {
+    test('should have same thresholds as 2024-25 (NBR official)', () => {
+      const nbr2024Thresholds = {
         general: 350000,
         female: 400000,
         disabled: 475000,
         freedom_fighter: 500000
       };
 
-      expect(TAX_FREE_THRESHOLDS_2025.general).toBeGreaterThan(oldThresholds.general);
-      expect(TAX_FREE_THRESHOLDS_2025.female).toBeGreaterThan(oldThresholds.female);
-      expect(TAX_FREE_THRESHOLDS_2025.disabled).toBeGreaterThan(oldThresholds.disabled);
-      expect(TAX_FREE_THRESHOLDS_2025.freedom_fighter).toBeGreaterThan(oldThresholds.freedom_fighter);
+      expect(TAX_FREE_THRESHOLDS_2025.general).toBe(nbr2024Thresholds.general);
+      expect(TAX_FREE_THRESHOLDS_2025.female).toBe(nbr2024Thresholds.female);
+      expect(TAX_FREE_THRESHOLDS_2025.disabled).toBe(nbr2024Thresholds.disabled);
+      expect(TAX_FREE_THRESHOLDS_2025.freedom_fighter).toBe(nbr2024Thresholds.freedom_fighter);
     });
 
-    test('should have fewer slabs than 2024-25 (6 vs 7)', () => {
-      const slabs = calculateTaxSlabs2025(375000);
-      expect(slabs).toHaveLength(6); // 2025-26 has 6 slabs, 2024-25 had 7
+    test('should have same number of slabs as 2024-25 (7 slabs)', () => {
+      const slabs = calculateTaxSlabs2025(350000);
+      expect(slabs).toHaveLength(7); // Same as 2024-25 per NBR official
     });
 
-    test('should not have 5% tax bracket', () => {
-      const slabs = calculateTaxSlabs2025(375000);
+    test('should have 5% tax bracket (same as 2024-25)', () => {
+      const slabs = calculateTaxSlabs2025(350000);
       const rates = slabs.map(slab => slab[3]);
-      expect(rates).not.toContain(5); // 5% bracket removed in 2025-26
+      expect(rates).toContain(5); // 5% bracket same as 2024-25 per NBR official
     });
   });
 });


### PR DESCRIPTION
Closes #44

Fixes tax slab mismatches for FY 2024-2025 and FY 2025-2026 as reported in #44:
- Remove incorrect 30% rate above 38.5 lakh (FY 2024-2025)
- Correct FY 2025-2026 first slab from 3.75L to 3.5L
- Add missing 5% bracket [3.5-4.5 lakh]
- Updated tests to match