### PR TITLE
fix: drop Node 14 from CI matrix, upgrade actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,13 @@ jobs:
     
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [18.x, 20.x]
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'


### PR DESCRIPTION
CI has been broken since the `engines: {node: >=16}` constraint was added — Node 14 always fails at `yarn install` and cancels the 16/18 jobs.

- Drop Node 14.x and 16.x (both EOL)
- Keep 18.x (LTS) and add 20.x (current LTS)
- Upgrade `actions/checkout` and `actions/setup-node` from v3 to v4